### PR TITLE
Fix UnitSelector ambiguities with explicit type prefixes

### DIFF
--- a/pixie-server/src/state/units.rs
+++ b/pixie-server/src/state/units.rs
@@ -21,17 +21,31 @@ pub enum UnitSelector {
 
 impl UnitSelector {
     /// Parse a [`UnitSelector`] from a [`String`].
+    ///
+    /// Every selector other than `all` is required to carry an explicit
+    /// `mac:`, `ip:`, `group:` or `image:` prefix. Without such a tag, a
+    /// group or image whose name happens to parse as a mac/ip address, or
+    /// whose name is `all`, or whose name collides with another group or
+    /// image, would be unreachable or would resolve to the wrong unit(s).
     pub fn parse(state: &State, selector: String) -> Option<UnitSelector> {
-        if let Ok(mac) = selector.parse::<MacAddr6>() {
-            Some(UnitSelector::MacAddr(mac))
-        } else if let Ok(ip) = selector.parse::<Ipv4Addr>() {
-            Some(UnitSelector::IpAddr(ip))
-        } else if selector == "all" {
+        if selector == "all" {
             Some(UnitSelector::All)
-        } else if let Some(&group) = state.config.groups.get_by_first(&selector) {
-            Some(UnitSelector::Group(group))
-        } else if state.config.images.contains(&selector) {
-            Some(UnitSelector::Image(selector))
+        } else if let Some(mac) = selector.strip_prefix("mac:") {
+            mac.parse::<MacAddr6>().ok().map(UnitSelector::MacAddr)
+        } else if let Some(ip) = selector.strip_prefix("ip:") {
+            ip.parse::<Ipv4Addr>().ok().map(UnitSelector::IpAddr)
+        } else if let Some(group) = selector.strip_prefix("group:") {
+            state
+                .config
+                .groups
+                .get_by_first(&group.to_owned())
+                .map(|&group| UnitSelector::Group(group))
+        } else if let Some(image) = selector.strip_prefix("image:") {
+            state
+                .config
+                .images
+                .contains(&image.to_owned())
+                .then(|| UnitSelector::Image(image.to_owned()))
         } else {
             None
         }

--- a/pixie-web/src/main.rs
+++ b/pixie-web/src/main.rs
@@ -24,9 +24,9 @@ fn send_req(url: String) {
 #[component]
 fn Images(#[prop(into)] images: Signal<Option<ImagesStats>>) -> impl IntoView {
     let image_row = move |(full_name, image): (String, (u64, u64))| {
-        let url_flash = format!("admin/action/{full_name}/flash");
-        let url_boot = format!("admin/action/{full_name}/boot");
-        let url_cancel = format!("admin/action/{full_name}/wait");
+        let url_flash = format!("admin/action/image:{full_name}/flash");
+        let url_boot = format!("admin/action/image:{full_name}/boot");
+        let url_cancel = format!("admin/action/image:{full_name}/wait");
         let url_rollback = format!("admin/rollback/{full_name}");
         let url_delete = format!("admin/delete/{full_name}");
 
@@ -146,14 +146,14 @@ fn Group(
         let ping_ago = move || time.get() - unit.get().last_ping_timestamp as i64;
 
         let mac = move || unit.get().mac.to_string();
-        let url_flash = move || format!("admin/action/{}/flash", mac());
-        let url_store = move || format!("admin/action/{}/store", mac());
-        let url_boot = move || format!("admin/action/{}/boot", mac());
-        let url_restart = move || format!("admin/action/{}/restart", mac());
-        let url_cancel = move || format!("admin/action/{}/wait", mac());
-        let url_register = move || format!("admin/action/{}/register", mac());
-        let url_shutdown = move || format!("admin/action/{}/shutdown", mac());
-        let url_forget = move || format!("admin/forget/{}", mac());
+        let url_flash = move || format!("admin/action/mac:{}/flash", mac());
+        let url_store = move || format!("admin/action/mac:{}/store", mac());
+        let url_boot = move || format!("admin/action/mac:{}/boot", mac());
+        let url_restart = move || format!("admin/action/mac:{}/restart", mac());
+        let url_cancel = move || format!("admin/action/mac:{}/wait", mac());
+        let url_register = move || format!("admin/action/mac:{}/register", mac());
+        let url_shutdown = move || format!("admin/action/mac:{}/shutdown", mac());
+        let url_forget = move || format!("admin/forget/mac:{}", mac());
 
         let fmt_ca = move || {
             let unit = unit.get();
@@ -240,14 +240,14 @@ fn Group(
         .into_view()
     };
 
-    let url_flash = move || format!("admin/action/{}/flash", group_name.get());
-    let url_boot = move || format!("admin/action/{}/boot", group_name.get());
-    let url_restart = move || format!("admin/action/{}/restart", group_name.get());
-    let url_cancel = move || format!("admin/action/{}/wait", group_name.get());
+    let url_flash = move || format!("admin/action/group:{}/flash", group_name.get());
+    let url_boot = move || format!("admin/action/group:{}/boot", group_name.get());
+    let url_restart = move || format!("admin/action/group:{}/restart", group_name.get());
+    let url_cancel = move || format!("admin/action/group:{}/wait", group_name.get());
 
     let image_button = move |image: String| {
         let text = format!("Set image to {image:?}");
-        let url = move || format!("admin/image/{}/{}", group_name.get(), image);
+        let url = move || format!("admin/image/group:{}/{}", group_name.get(), image);
         view! {
             <Button color=ButtonColor::Error on_click=move |_| send_req(url())>
                 {text}

--- a/run_test.sh
+++ b/run_test.sh
@@ -120,7 +120,7 @@ for PART in ${DEV}p{2..3}; do
 done
 losetup -d $DEV
 
-curl 'http://localhost:8080/admin/curr_action/52:54:00:12:34:56/store'
+curl 'http://localhost:8080/admin/curr_action/mac:52:54:00:12:34:56/store'
 run_qemu $TEMPDIR/store.log
 
 # Check that we restore the original disk image.


### PR DESCRIPTION
## Summary
- `UnitSelector::parse` tried mac → ip → `all` → group → image in a fixed priority order, so a group/image named `all`, one whose name happened to parse as a mac/ip address, or one colliding with another group/image name was unreachable or resolved to the wrong unit(s).
- Selectors now require an explicit `mac:`, `ip:`, `group:` or `image:` prefix (`all` stays a bare keyword), which removes the ambiguity entirely.
- Updated the web admin UI (`pixie-web/src/main.rs`) and `run_test.sh` to build selector strings with the new prefixes.

Fixes #91

## Test plan
- [x] `cargo build` / `cargo clippy` in `pixie-server` (clean)
- [x] `cargo build --target wasm32-unknown-unknown` in `pixie-web` (clean)
- [ ] Full `run_test.sh` end-to-end run (requires qemu/root privileges, not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014y53s9uDYxdzudW2cPGFKB