### PR TITLE
Fix HostsConfig doc comment: row/column octet order was swapped

### DIFF
--- a/pixie-shared/src/config.rs
+++ b/pixie-shared/src/config.rs
@@ -27,7 +27,7 @@ pub struct InterfaceConfig {
 }
 
 /// Registered clients will always be assigned an IP in the form
-/// 10.{group_id}.{column_id}.{row_id}.
+/// 10.{group_id}.{row_id}.{column_id}.
 /// Note that for this to work, the specified network interface must have an IP on the 10.0.0.0/8
 /// subnet; BEWARE that dnsmasq can be picky about the order of IP addresses.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## Summary
- `HostsConfig`'s doc comment said assigned IPs are `10.{group}.{column}.{row}`, but `Unit::static_ip()` actually builds `10.{group}.{row}.{column}` — doc-only fix, no functional change.

## Test plan
- [x] Diff limited to a comment; `cargo check -p pixie-shared` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gfNJUxo5wmiy87RTuf3y7