### PR TITLE
Fix server crash from Register requests with an unknown group

### DIFF
--- a/pixie-server/src/tcp.rs
+++ b/pixie-server/src/tcp.rs
@@ -28,8 +28,8 @@ async fn handle_request(state: &State, req: TcpRequest, peer_mac: MacAddr6) -> R
             state.get_image_serialized(&unit.image)?.unwrap()
         }
         TcpRequest::Register(station) => {
-            state.set_registration_hint(station.clone());
-            state.register_unit(peer_mac, station)?;
+            state.register_unit(peer_mac, station.clone())?;
+            state.set_registration_hint(station);
             Vec::new()
         }
         TcpRequest::UploadChunk(data) => {


### PR DESCRIPTION
## Summary
- `pixie-server/src/tcp.rs`'s `TcpRequest::Register` handler stored the registration hint (`set_registration_hint`) *before* `register_unit` validated the request's `group` against `config.yaml`.
- A `Register` request with an unknown group is rejected by `register_unit`, but the bad hint had already been saved. About a second later, the periodic hint broadcaster (`udp.rs::compute_hint`) does `state.config.groups.get_by_first(&last.group).unwrap()`, which panics on the unknown group — and since that task is joined all the way up through `tokio::try_join!` in `main()`, the panic takes down the entire server process.
- No authentication is required to send `Register` over TCP, so this is a one-packet, unauthenticated crash of the whole server.

Fix: swap the order so the hint is only saved once `register_unit` has confirmed the group and image are valid.

## Test plan
- [x] `cargo build` (pixie-server) — clean
- [x] `cargo clippy` (pixie-server) — clean
- [ ] Manual: send a `TcpRequest::Register` with a nonexistent group against a running server and confirm the server no longer crashes ~1s later

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yDx5obQfUVVGoz1o88MDg