### PR TITLE
Fix panic on GetImage for a configured-but-not-yet-stored image

### DIFF
--- a/pixie-server/src/tcp.rs
+++ b/pixie-server/src/tcp.rs
@@ -25,7 +25,9 @@ async fn handle_request(state: &State, req: TcpRequest, peer_mac: MacAddr6) -> R
         }
         TcpRequest::GetImage => {
             let unit = state.get_unit(peer_mac).context("Unit not found")?;
-            state.get_image_serialized(&unit.image)?.unwrap()
+            state
+                .get_image_serialized(&unit.image)?
+                .context("Image not yet stored")?
         }
         TcpRequest::Register(station) => {
             state.set_registration_hint(station.clone());


### PR DESCRIPTION
## Summary
- `TcpRequest::GetImage` unwrapped `get_image_serialized`'s `Ok(None)` case, which happens whenever a unit is assigned to an image that's configured in `config.yaml` but hasn't been "Stored" yet — a normal, expected server state, not an edge case.
- Any unit (or anyone able to reach `ACTION_PORT` claiming that unit's MAC) sending `GetImage` in that state would panic the per-connection task instead of getting a clean error. The panic was contained to that one connection (its `JoinHandle` is never awaited), so it wasn't a server-wide crash, but it's an easy, expected-workflow trigger for an unhandled panic.
- Fix follows the same pattern already used one line above it in the same match arm: `anyhow::Context` on the `Option`, turning the missing-image case into a normal propagated error.

Found while auditing pixie's public HTTP/TCP/UDP API surface for bugs.

## Test plan
- [x] `cargo build` succeeds for `pixie-server`
- [ ] Manually verify: configure an image, assign a unit to it without storing data, send `GetImage` for that unit, confirm the connection now gets a clean error log instead of a panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bnT2tmDgDkaBV9hYJbY5a